### PR TITLE
Docs fixed: JwtTokenHelperImpl javadoc

### DIFF
--- a/src/main/java/com/enzulode/auth/util/JwtTokenHelperImpl.java
+++ b/src/main/java/com/enzulode/auth/util/JwtTokenHelperImpl.java
@@ -30,6 +30,7 @@ public class JwtTokenHelperImpl implements TokenHelper
 	 * This method validates token.
 	 *
 	 * @param token token being validated
+	 * @throws SignatureException if token is expired
 	 */
 	@Override
 	public void verifyToken(String token) throws SignatureException


### PR DESCRIPTION
JwtTokenHelperImpl's verifyToken() method now has correct exception throwing information